### PR TITLE
tweak FET calculation

### DIFF
--- a/features/strategies/components/Swap/Results.tsx
+++ b/features/strategies/components/Swap/Results.tsx
@@ -34,11 +34,20 @@ export function SwapResults({
     isLoadingToOcean
   } = useQuote(tokenSymbol, amount, isUniswap)
 
-  const amountInUsd =
-    amount * prices[tokenSymbol.toLowerCase() as keyof Prices].usd
+  const tokenSelected = tokenSymbol.toLowerCase() as keyof Prices
+
+  const amountInUsd = amount * prices[tokenSelected].usd
   const amountToOcean = amountInUsd / prices.ocean.usd
   const amountToAgix = amountInUsd / prices.agix.usd
-  const amountToFet = amountInUsd / prices.fet.usd
+
+  // As of July 1st, use fixed ratios instead of FET market price
+  // as the markets for OCEAN & AGIX are limited
+  const amountToFet =
+    tokenSelected === 'ocean'
+      ? amount * ratioOceanToAsi
+      : tokenSelected === 'agix'
+        ? amount * ratioAgixToAsi
+        : amount
 
   return (
     <>


### PR DESCRIPTION
* As of July 1st, use fixed ratios instead of FET market price as the markets for OCEAN & AGIX are limited
* migration contracts guarantee fixed rate so no need for market rates for OCEAN/FET or AGIX/FET


Before:

<img width="508" alt="Screenshot 2024-07-01 at 16 22 43" src="https://github.com/kremalicious/asi-calculator/assets/90316/5d5ac393-b4a3-4871-a920-fc89d80feeb4">

After:

<img width="497" alt="Screenshot 2024-07-01 at 16 22 54" src="https://github.com/kremalicious/asi-calculator/assets/90316/d3bc6553-0b3c-4b88-b782-44df33bb97c9">

